### PR TITLE
we are boiii

### DIFF
--- a/src/client/component/ui_scripting.cpp
+++ b/src/client/component/ui_scripting.cpp
@@ -206,6 +206,7 @@ namespace ui_scripting
 			lua["table"]["unpack"] = lua["unpack"];
 			lua["luiglobals"] = lua;
 			lua["Engine"]["is_t7x"] = true;
+			lua["Engine"]["IsBOIII"] = true;
 		}
 
 		void start()


### PR DESCRIPTION
not sure if this is how it wants to be dealt with, but shouldn't we also support this variable? i know people could update their mods but to be honest, mods that built around `IsBOIII` probably use `is_t7x` too (assuming the whole LUI safety thing isn't changed)